### PR TITLE
ITOP-4033 Fix heap and non-heap memory collection

### DIFF
--- a/conf/jvm-memory.json
+++ b/conf/jvm-memory.json
@@ -13,7 +13,7 @@
         "retentionPolicy" : "${TARGET_INFLUXDB_RETENTION_POLICY}",
         "username" : "${TARGET_INFLUXDB_USERNAME}",
         "password" : "${TARGET_INFLUXDB_PASSWORD}",
-        "resultTags":["typeName","className"],
+        "resultTags":["typeName","className","attributeName"],
         "tags" : {
           "host" : "${TARGET_HOSTNAME}",
           "node" : "${TARGET_NODE_ID}"


### PR DESCRIPTION
Avoid the head and non heap metrics to override each others as they have the same id without the attributeName